### PR TITLE
set the origin for post message

### DIFF
--- a/boku.html
+++ b/boku.html
@@ -25,7 +25,9 @@
 
     <script>
 
-        var orgurl = undefined;
+        // Set this to the origin to be the same as the opener window, probably has to be done at transaction setup
+        // time as you won't be able to read it from the window and we have different domains
+        var orgurl = 'http://netproteus.com';
         var callBackUrl = window.location.origin + '/boku-test' + '/result.html?paymentId=1&type=boku';
 
         function onHandlerClick() {


### PR DESCRIPTION
If https://github.com/netproteus/badoobokutest/pull/1 is not an option then set the orgurl in the controller parameters so that the window can actually post a message to the parent. This will require a hack on our side but is workable. We have different domains so this will need to be configurable somehow.
